### PR TITLE
Deal with callstack get errors

### DIFF
--- a/instrument.js
+++ b/instrument.js
@@ -118,6 +118,14 @@ function logError(src, error, position) {
   // write different data to remote console
   // and window console.
   write('error', [errorLines.join('\n') + '\n'])
-  write('error', [error.stack])
+  
+  // it's possible that we can fail to get a stack
+  try {
+    write('error', [error.stack])
+  }
+  catch (e) {
+    write('error', ['Could not get stack trace because:', e.message])
+  }
+
   nativeConsole.error(error)
 }


### PR DESCRIPTION
Apparently, it's possible to error out when getting a stack trace from an error object. I didn't know this until I ran into it in my own project. This at least lets the user know that the there's no call stack coming and allows the browser to close.