### PR TITLE
client: convert-sourcemap now assumes large source

### DIFF
--- a/instrument.js
+++ b/instrument.js
@@ -68,7 +68,10 @@ shoe.on('end', function() {
 xhr('script.js', function(err, resp) {
   if (err) return console.error(err)
   var src = resp.body
-  var sourceMap = convert.fromSource(src)
+  // large sourcemaps will fail to parse, this is suprisingly common.
+  // so, we'll use the "large source map option", which is faster anyway
+  var sourceMap = convert.fromSource(src, true)
+
   // Not all browsers support the full function signature
   // of window.onerror, so the Error instance is not always
   // guaranteed:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bl": "^0.9.3",
     "chrome-launch": "^1.1.1",
-    "convert-source-map": "^0.4.1",
+    "convert-source-map": "^0.6.0",
     "debug": "^2.0.0",
     "firefox-launch": "^1.0.0",
     "is-dom": "~1.0.4",


### PR DESCRIPTION
Makes us far less error prone and faster!