### PR TITLE
Fix env vars

### DIFF
--- a/bin/smokestack.js
+++ b/bin/smokestack.js
@@ -27,9 +27,9 @@ if (argv.help) {
 }
 
 var browser = ss({
-  saucelabs: argv.saucelabs,
-  sauceUsername: argv.username,
-  sauceKey: argv.key,
+  saucelabs: argv.saucelabs || process.env.SAUCE,
+  sauceUsername: argv.username || process.env.SAUCE_USERNAME,
+  sauceKey: argv.key || process.env.SAUCE_ACCESS_KEY,
   browser: argv.browser,
   port: argv.port
 })


### PR DESCRIPTION
Currently there is an object that is passed in from bin that is overriding the env vars. I added an env check in bin, and set the env check to happen first.

Up for discussion on this